### PR TITLE
Improve request validation for Magento 2.3.0

### DIFF
--- a/Controller/Checkout/Confirm.php
+++ b/Controller/Checkout/Confirm.php
@@ -34,9 +34,12 @@ namespace Wirecard\CheckoutSeamless\Controller\Checkout;
 
 use Magento\Checkout\Model\Cart as CheckoutCart;
 use Magento\Framework\Exception\InputException;
+use Magento\Framework\App\CsrfAwareActionInterface;
+use Wirecard\ElasticEngine\Controller\Frontend\NoCsrfTrait;
 
-class Confirm extends \Magento\Framework\App\Action\Action
+class Confirm extends \Magento\Framework\App\Action\Action implements CsrfAwareActionInterface
 {
+    use NoCsrfTrait;
 
     /**
      * @var \Magento\Framework\HTTP\PhpEnvironment\Request
@@ -101,31 +104,31 @@ class Confirm extends \Magento\Framework\App\Action\Action
             $return = \WirecardCEE_QMore_ReturnFactory::getInstance($this->_request->getPost()->toArray(),
                 $this->_dataHelper->getConfigData('basicdata/secret'));
 
-	        $error = "";
-	        if (!$return->validate()) {
-		        $error = 'Validation error: invalid response';
-	        }
+            $error = "";
+            if (!$return->validate()) {
+                $error = 'Validation error: invalid response';
+            }
 
-	        if (!strlen($return->mage_orderId)) {
-		        $error = 'Magento OrderId is missing';
-	        }
+            if (!strlen($return->mage_orderId)) {
+                $error = 'Magento OrderId is missing';
+            }
 
-	        if (!strlen($return->mage_quoteId)) {
-		        $error = 'Magento QuoteId is missing';
-	        }
+            if (!strlen($return->mage_quoteId)) {
+                $error = 'Magento QuoteId is missing';
+            }
 
-	        if (strlen($error)) {
-		        die( \WirecardCEE_QMore_ReturnFactory::generateConfirmResponseString($error) );
-	        }
+            if (strlen($error)) {
+                die(\WirecardCEE_QMore_ReturnFactory::generateConfirmResponseString($error));
+            }
 
             $this->_orderManagement->processOrder($return);
 
-            die( \WirecardCEE_QMore_ReturnFactory::generateConfirmResponseString() );
+            die(\WirecardCEE_QMore_ReturnFactory::generateConfirmResponseString());
         } catch (\Exception $e) {
             $this->_logger->debug(__METHOD__ . ':' . $e->getMessage());
             $this->_logger->debug(__METHOD__ . ':' . $e->getTraceAsString());
 
-            die( \WirecardCEE_QMore_ReturnFactory::generateConfirmResponseString($e->getMessage()) );
+            die(\WirecardCEE_QMore_ReturnFactory::generateConfirmResponseString($e->getMessage()));
         }
     }
 }

--- a/Controller/Checkout/Start.php
+++ b/Controller/Checkout/Start.php
@@ -104,7 +104,6 @@ class Start extends \Magento\Framework\App\Action\Action
                 ['_secure' => true, '_nosid' => true])
         ];
 
-
         $payment = null;
         try {
             if ($this->getCheckoutMethod() == \Magento\Checkout\Model\Type\Onepage::METHOD_GUEST) {

--- a/Model/AbstractPayment.php
+++ b/Model/AbstractPayment.php
@@ -434,8 +434,8 @@ abstract class AbstractPayment extends AbstractMethod
         $infoInstance = $this->getInfoInstance();
 
         /* unset data wich is used for dedicated payment methods only */
-        $infoInstance->unsAdditionalInformation('financialInstitution');
-        $infoInstance->unsAdditionalInformation('customerDob');
+        $infoInstance->setAdditionalInformation('financialInstitution', '');
+        $infoInstance->setAdditionalInformation('customerDob', '');
 
         return $this;
     }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "magento/module-sales": "*",
     "magento/module-payment": "*",
     "magento/module-quote": "*",
-    "wirecard/checkout-client-library": "3.3.5"
+    "wirecard/checkout-client-library": "3.3.5",
+    "wirecard/magento2-ee-compat": "^1.0.0 || ^2.0.0"
   },
   "autoload": {
     "files": [


### PR DESCRIPTION
### This PR

* Resolves a request validation problem introduced with Magento 2.3.0 which in turn caused an `orderCreation is missing` issue.
* Resolves the `FINANCIALINSTITUTION is invalid` issue caused by some payment methods.

### Notes

* To maintain backward compatibility with Magento 2.1-2.2 a compat package (magento2-ee-compat, version 1.0.0 for < magento 2.3.0 and version 2.0.0 for >= magento 2.3.0) is used

### How to test

* Use Magento 2.2.6 and 2.3.0 to perform test payments
    * first with eps
    * then with Credit Card
* The payments should go through correctly